### PR TITLE
TailwindCSS 4 and Laravel 13

### DIFF
--- a/.github/workflows/pint.yaml.yml
+++ b/.github/workflows/pint.yaml.yml
@@ -1,0 +1,39 @@
+name: Fix Code Style
+
+on:
+  push:
+
+jobs:
+  phplint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            **.php
+
+      - name: "laravel-pint"
+        uses: aglipanci/laravel-pint-action@v2
+        with:
+          preset: laravel
+          verboseMode: true
+          onlyDirty: true
+
+      - name: Commit linted files
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: Fix styling

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
           - laravel: 11.*
             statamic: 6.*
           - laravel: 13.*
+            statamic: 5.*
+          - laravel: 13.*
             php: 8.2
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Statamic ${{ matrix.statamic }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        statamic: [5.*, 6]
+        statamic: [5.*, 6.*]
         laravel: [11.*, 12.*, 13.*]
         os: [ubuntu-latest]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,8 @@ jobs:
         laravel: [11.*, 12.*, 13.*]
         os: [ubuntu-latest]
         exclude:
-          - laravel: 11.*
-            php: 8.5
-          - laravel: 13.*
-            php: 8.2
+          - statamic: 6.*
+            laravel: 11.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Statamic ${{ matrix.statamic }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,10 @@ jobs:
         laravel: [11.*, 12.*, 13.*]
         os: [ubuntu-latest]
         exclude:
-          - statamic: 6.*
-            laravel: 11.*
+          - laravel: 11.*
+            statamic: 6.*
+          - laravel: 13.*
+            php: 8.2
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Statamic ${{ matrix.statamic }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,18 @@ jobs:
   php_tests:
     strategy:
       matrix:
-        php: [8.2, 8.3]
-        laravel: [11.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        statamic: [5.*, 6]
+        laravel: [11.*, 12.*, 13.*]
+        livewire: [3.*, 4.*]
         os: [ubuntu-latest]
+        exclude:
+          - laravel: 11.*
+            php: 8.5
+          - laravel: 13.*
+            php: 8.2
 
-    name: ${{ matrix.php }} - ${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Statamic ${{ matrix.statamic }}
 
     runs-on: ${{ matrix.os }}
 
@@ -29,6 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "statamic/cms:${{ matrix.statamic }}" --no-interaction --no-update
           composer install --no-interaction
 
       - name: Run PHPUnit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
         php: [8.2, 8.3, 8.4, 8.5]
         statamic: [5.*, 6]
         laravel: [11.*, 12.*, 13.*]
-        livewire: [3.*, 4.*]
         os: [ubuntu-latest]
         exclude:
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,14 @@
         }
     },
     "require": {
-        "gehrisandro/tailwind-merge-laravel": "^1.0.0",
-        "statamic/cms": "^4.0|^5.0|^6.0"
+        "laravel/framework": "^11.0 || ^12.0 || ^13.0",
+        "marcorieser/tailwind-merge-laravel": "^0.1.0",
+        "statamic/cms": "^5.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0"
+        "laravel/pint": "^1.21",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "phpunit/phpunit": "^10.5|^11.0|^12.0"
     },
     "config": {
         "allow-plugins": {

--- a/src/Modifiers/TwMerge.php
+++ b/src/Modifiers/TwMerge.php
@@ -2,8 +2,8 @@
 
 namespace MarcoRieser\TailwindMergeStatamic\Modifiers;
 
+use MarcoRieser\TailwindMergeLaravel\Facades\TailwindMerge;
 use Statamic\Modifiers\Modifier;
-use TailwindMerge\Laravel\Facades\TailwindMerge;
 
 class TwMerge extends Modifier
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,16 +2,16 @@
 
 namespace MarcoRieser\TailwindMergeStatamic\Tests;
 
+use MarcoRieser\TailwindMergeLaravel\TailwindMergeServiceProvider;
 use MarcoRieser\TailwindMergeStatamic\ServiceProvider;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Testing\AddonTestCase;
-use TailwindMerge\Laravel\TailwindMergeServiceProvider;
 
 abstract class TestCase extends AddonTestCase
 {
     protected string $addonServiceProvider = ServiceProvider::class;
 
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         $serviceProviders = parent::getPackageProviders($app);
 


### PR DESCRIPTION
This PR allows the usage under Laravel 13 by using https://github.com/tales-from-a-dev/tailwind-merge-php for the merge logic under the hood. By that, the addon becomes only compatible with TailwindCSS v4.

Closes: #6 